### PR TITLE
Fix: bucket name length exceeds 63 characters with non-US region deployment

### DIFF
--- a/1-org/modules/cai-monitoring/main.tf
+++ b/1-org/modules/cai-monitoring/main.tf
@@ -26,8 +26,7 @@ locals {
     "run.googleapis.com",
     "eventarc.googleapis.com"
   ]
-  cai_source_name              = var.random_suffix ? "CAI Monitoring - ${random_id.suffix.hex}" : "CAI Monitoring"
-  cai_monitoring_bucket_suffix = "${random_id.suffix.hex}-sources-${data.google_project.project.number}-${var.location}"
+  cai_source_name = var.random_suffix ? "CAI Monitoring - ${random_id.suffix.hex}" : "CAI Monitoring"
 }
 
 data "google_project" "project" {
@@ -75,7 +74,7 @@ module "cloudfunction_source_bucket" {
   version = "~> 6.0"
 
   project_id    = var.project_id
-  name          = "bkt-cai-monitoring-${md5(local.cai_monitoring_bucket_suffix)}"
+  name          = "bkt-cai-monitoring-${random_id.suffix.hex}-sources-${data.google_project.project.number}"
   location      = var.location
   storage_class = "REGIONAL"
   force_destroy = true

--- a/1-org/modules/cai-monitoring/main.tf
+++ b/1-org/modules/cai-monitoring/main.tf
@@ -26,7 +26,8 @@ locals {
     "run.googleapis.com",
     "eventarc.googleapis.com"
   ]
-  cai_source_name = var.random_suffix ? "CAI Monitoring - ${random_id.suffix.hex}" : "CAI Monitoring"
+  cai_source_name              = var.random_suffix ? "CAI Monitoring - ${random_id.suffix.hex}" : "CAI Monitoring"
+  cai_monitoring_bucket_suffix = "${random_id.suffix.hex}-sources-${data.google_project.project.number}-${var.location}"
 }
 
 data "google_project" "project" {
@@ -74,7 +75,7 @@ module "cloudfunction_source_bucket" {
   version = "~> 6.0"
 
   project_id    = var.project_id
-  name          = "bkt-cai-monitoring-${random_id.suffix.hex}-sources-${data.google_project.project.number}-${var.location}"
+  name          = "bkt-cai-monitoring-${md5(local.cai_monitoring_bucket_suffix)}"
   location      = var.location
   storage_class = "REGIONAL"
   force_destroy = true

--- a/4-projects/modules/base_env/example_storage_cmek.tf
+++ b/4-projects/modules/base_env/example_storage_cmek.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+locals {
+  cmek_bucket_prefix = "${var.gcs_bucket_prefix}-cmek-encrypted"
+  cmek_bucket_suffix = "${module.base_shared_vpc_project.project_id}-${lower(var.location_gcs)}-${random_string.bucket_name.result}"
+}
+
 data "google_storage_project_service_account" "gcs_account" {
   project = module.base_shared_vpc_project.project_id
 }
@@ -44,11 +49,11 @@ resource "random_string" "bucket_name" {
 
 module "gcs_buckets" {
   source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
-  version = "~> 6.0"
+  version = "~> 6.0.0"
 
   project_id              = module.base_shared_vpc_project.project_id
   location                = var.location_gcs
-  name                    = "${var.gcs_bucket_prefix}-${module.base_shared_vpc_project.project_id}-${lower(var.location_gcs)}-cmek-encrypted-${random_string.bucket_name.result}"
+  name                    = "${local.cmek_bucket_prefix}-${md5(local.cmek_bucket_suffix)}"
   bucket_policy_only      = true
   custom_placement_config = var.gcs_custom_placement_config
 

--- a/4-projects/modules/base_env/example_storage_cmek.tf
+++ b/4-projects/modules/base_env/example_storage_cmek.tf
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-locals {
-  cmek_bucket_prefix = "${var.gcs_bucket_prefix}-cmek-encrypted"
-  cmek_bucket_suffix = "${module.base_shared_vpc_project.project_id}-${lower(var.location_gcs)}-${random_string.bucket_name.result}"
-}
-
 data "google_storage_project_service_account" "gcs_account" {
   project = module.base_shared_vpc_project.project_id
 }
@@ -53,7 +48,7 @@ module "gcs_buckets" {
 
   project_id              = module.base_shared_vpc_project.project_id
   location                = var.location_gcs
-  name                    = "${local.cmek_bucket_prefix}-${md5(local.cmek_bucket_suffix)}"
+  name                    = "${var.gcs_bucket_prefix}-${module.base_shared_vpc_project.project_id}-cmek-encrypted-${random_string.bucket_name.result}"
   bucket_policy_only      = true
   custom_placement_config = var.gcs_custom_placement_config
 


### PR DESCRIPTION
Hey folks, this PR contains changes to the structure of bucket names, so that when the deployment is made in a region with a long name, such as "northamerica-northeast1", the bucket does not exceed the 63 character limit.